### PR TITLE
[Feature] 이벤트 리스너로 이벤트 처리, TaskScheduler로 게임 종료 예약

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,6 +44,8 @@ dependencies {
 
 	//webclient
 	implementation 'org.springframework.boot:spring-boot-starter-webflux' // WebClient 사용 가능
+
+	implementation 'org.springframework.boot:spring-boot-starter-aop'
 }
 
 tasks.named('test') {

--- a/src/main/java/prography/pingpong_game/common/event/GameEventListener.java
+++ b/src/main/java/prography/pingpong_game/common/event/GameEventListener.java
@@ -1,38 +1,42 @@
 package prography.pingpong_game.common.event;
 
-import jakarta.persistence.EntityManager;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.TaskScheduler;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
 import prography.pingpong_game.room.service.RoomService;
-import prography.pingpong_game.room.service.UserRoomService;
+
+import java.time.Instant;
 
 @Component
 @RequiredArgsConstructor
 @Slf4j
+@EnableAsync
+@EnableScheduling
 public class GameEventListener {
 	private final RoomService roomService;
-	private final UserRoomService userRoomService;
-	private final EntityManager entityManager;
-
-	//TODO : 공부 하기
+	private final TaskScheduler taskScheduler;
+	private static final int GAME_DURATION_SECONDS = 60;
 	@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
 	public void startGame(GameStartEvent gameStartEvent) {
-		try {
-			log.info("게임 종료");
-//			finishGame(gameStartEvent);
-		} catch (Exception e) {
-			log.error("게임 종료 처리 중 오류 발생", e);
-		}
+		log.info("게임 시작 : roomId = {}", gameStartEvent.roomId());
+		scheduleFinishGame(gameStartEvent.roomId());
 	}
 
-//	@Transactional(propagation = Propagation.REQUIRES_NEW)
-//	public void finishGame(GameStartEvent gameStartEvent) {
-//		Room updatedRoom = roomService.findRoomWithCapacity(gameStartEvent.roomId());
-//		updatedRoom.finishGame();
-//		userRoomService.deleteAllUserRooms(updatedRoom.getId());
-//		log.info("게임이 종료되었습니다");
-//	}
+	@Async
+	public void scheduleFinishGame(Long roomId) {
+		taskScheduler.schedule(
+				() -> finishGame(roomId),
+				Instant.now().plusSeconds(GAME_DURATION_SECONDS)
+		);
+	}
+	private void finishGame(Long roomId) {
+		log.info("게임 종료");
+		roomService.finishGame(roomId);
+	}
 }

--- a/src/main/java/prography/pingpong_game/common/event/GameEventListener.java
+++ b/src/main/java/prography/pingpong_game/common/event/GameEventListener.java
@@ -1,0 +1,38 @@
+package prography.pingpong_game.common.event;
+
+import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+import prography.pingpong_game.room.service.RoomService;
+import prography.pingpong_game.room.service.UserRoomService;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class GameEventListener {
+	private final RoomService roomService;
+	private final UserRoomService userRoomService;
+	private final EntityManager entityManager;
+
+	//TODO : 공부 하기
+	@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+	public void startGame(GameStartEvent gameStartEvent) {
+		try {
+			log.info("게임 종료");
+//			finishGame(gameStartEvent);
+		} catch (Exception e) {
+			log.error("게임 종료 처리 중 오류 발생", e);
+		}
+	}
+
+//	@Transactional(propagation = Propagation.REQUIRES_NEW)
+//	public void finishGame(GameStartEvent gameStartEvent) {
+//		Room updatedRoom = roomService.findRoomWithCapacity(gameStartEvent.roomId());
+//		updatedRoom.finishGame();
+//		userRoomService.deleteAllUserRooms(updatedRoom.getId());
+//		log.info("게임이 종료되었습니다");
+//	}
+}

--- a/src/main/java/prography/pingpong_game/common/event/GameStartEvent.java
+++ b/src/main/java/prography/pingpong_game/common/event/GameStartEvent.java
@@ -1,0 +1,5 @@
+package prography.pingpong_game.common.event;
+
+
+public record GameStartEvent(Long roomId) {
+}

--- a/src/main/java/prography/pingpong_game/config/AsyncConfig.java
+++ b/src/main/java/prography/pingpong_game/config/AsyncConfig.java
@@ -1,0 +1,9 @@
+package prography.pingpong_game.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+
+@Configuration
+@EnableAsync
+public class AsyncConfig {
+}

--- a/src/main/java/prography/pingpong_game/room/controller/RoomController.java
+++ b/src/main/java/prography/pingpong_game/room/controller/RoomController.java
@@ -8,6 +8,7 @@ import prography.pingpong_game.common.ApiResponse;
 import prography.pingpong_game.room.dto.request.AttendRequest;
 import prography.pingpong_game.room.dto.request.OutRoomRequest;
 import prography.pingpong_game.room.dto.request.RoomCreateRequest;
+import prography.pingpong_game.room.dto.request.StartGameRequest;
 import prography.pingpong_game.room.service.RoomService;
 
 @RequiredArgsConstructor
@@ -54,6 +55,16 @@ public class RoomController {
             @PathVariable Long roomId,
             @RequestBody OutRoomRequest outRoomRequest) {
         roomService.outRoom(roomId, outRoomRequest);
+        return ApiResponse.success();
+    }
+
+    @Operation(summary = "게임 시작 API", description = "게임을 시작합니다. ")
+    @PutMapping("/start/{roomId}")
+    public ApiResponse startGame(
+            @Parameter(description = "참여하고 있는 방 ID", example = "1")
+            @PathVariable Long roomId,
+            @RequestBody StartGameRequest startGameRequest) {
+        roomService.startGame(roomId, startGameRequest);
         return ApiResponse.success();
     }
 }

--- a/src/main/java/prography/pingpong_game/room/controller/TeamController.java
+++ b/src/main/java/prography/pingpong_game/room/controller/TeamController.java
@@ -1,5 +1,7 @@
 package prography.pingpong_game.room.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 import prography.pingpong_game.common.ApiResponse;
@@ -11,9 +13,12 @@ import prography.pingpong_game.room.service.RoomService;
 @RequiredArgsConstructor
 public class TeamController {
 	private final RoomService roomService;
-
+	@Operation(summary = "팀 변경 API", description = "팀을 변경합니다. ")
 	@PutMapping("/{roomId}")
-	public ApiResponse switchTeam(@PathVariable Long roomId, @RequestBody TeamSwitchRequest teamSwitchRequest) {
+	public ApiResponse switchTeam(
+			@Parameter(description = "참여하고 있는 방 ID", example = "1")
+			@PathVariable Long roomId,
+			@RequestBody TeamSwitchRequest teamSwitchRequest) {
 		roomService.switchTeam(roomId, teamSwitchRequest);
 		return ApiResponse.success();
 	}

--- a/src/main/java/prography/pingpong_game/room/dto/request/StartGameRequest.java
+++ b/src/main/java/prography/pingpong_game/room/dto/request/StartGameRequest.java
@@ -1,0 +1,9 @@
+package prography.pingpong_game.room.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record StartGameRequest(
+		@Schema(description = "호스트 유저 ID", example = "1")
+		Long userId
+) {
+}

--- a/src/main/java/prography/pingpong_game/room/entity/Room.java
+++ b/src/main/java/prography/pingpong_game/room/entity/Room.java
@@ -48,7 +48,7 @@ public class Room extends BaseEntity {
         return this.status == RoomStatus.WAIT;
     }
     public boolean isFull() {
-        return roomCapacity.isFull();
+        return this.roomCapacity.isFull();
     }
 
     public Team assignTeam() {
@@ -63,7 +63,11 @@ public class Room extends BaseEntity {
         roomCapacity.removeUserFromTeam(userRoom.getTeam());
     }
 
-    public void finish() {
+    public void startGame() {
+        this.status = RoomStatus.PROGRESS;
+    }
+
+    public void finishGame() {
         this.status = RoomStatus.FINISH;
         roomCapacity.removeAllUsers();
     }

--- a/src/main/java/prography/pingpong_game/room/exception/OnlyHostCanStartGameException.java
+++ b/src/main/java/prography/pingpong_game/room/exception/OnlyHostCanStartGameException.java
@@ -1,0 +1,10 @@
+package prography.pingpong_game.room.exception;
+
+import prography.pingpong_game.common.exception.ApiStatus;
+import prography.pingpong_game.common.exception.PingPongException;
+
+public class OnlyHostCanStartGameException extends PingPongException {
+	public OnlyHostCanStartGameException(ApiStatus apiStatus) {
+		super(apiStatus);
+	}
+}

--- a/src/main/java/prography/pingpong_game/room/exception/RoomIsFullException.java
+++ b/src/main/java/prography/pingpong_game/room/exception/RoomIsFullException.java
@@ -3,8 +3,8 @@ package prography.pingpong_game.room.exception;
 import prography.pingpong_game.common.exception.ApiStatus;
 import prography.pingpong_game.common.exception.PingPongException;
 
-public class RoomCapacityExceededException extends PingPongException {
-	public RoomCapacityExceededException(ApiStatus apiStatus) {
+public class RoomIsFullException extends PingPongException {
+	public RoomIsFullException(ApiStatus apiStatus) {
 		super(apiStatus);
 	}
 }

--- a/src/main/java/prography/pingpong_game/room/exception/RoomIsNotFullException.java
+++ b/src/main/java/prography/pingpong_game/room/exception/RoomIsNotFullException.java
@@ -1,0 +1,10 @@
+package prography.pingpong_game.room.exception;
+
+import prography.pingpong_game.common.exception.ApiStatus;
+import prography.pingpong_game.common.exception.PingPongException;
+
+public class RoomIsNotFullException extends PingPongException {
+	public RoomIsNotFullException(ApiStatus apiStatus) {
+		super(apiStatus);
+	}
+}

--- a/src/main/java/prography/pingpong_game/room/repository/RoomRepositoryCustom.java
+++ b/src/main/java/prography/pingpong_game/room/repository/RoomRepositoryCustom.java
@@ -4,6 +4,10 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import prography.pingpong_game.room.entity.Room;
 
+import java.util.Optional;
+
 public interface RoomRepositoryCustom {
 	Page<Room> findAllRooms(PageRequest pageable);
+
+	Optional<Room> findRoomWithCapacity(Long roomId);
 }

--- a/src/main/java/prography/pingpong_game/room/repository/RoomRepositoryImpl.java
+++ b/src/main/java/prography/pingpong_game/room/repository/RoomRepositoryImpl.java
@@ -9,8 +9,10 @@ import org.springframework.stereotype.Repository;
 import prography.pingpong_game.room.entity.Room;
 
 import java.util.List;
+import java.util.Optional;
 
 import static prography.pingpong_game.room.entity.QRoom.room;
+import static prography.pingpong_game.room.entity.QRoomCapacity.roomCapacity;
 
 @Repository
 @RequiredArgsConstructor
@@ -27,6 +29,16 @@ public class RoomRepositoryImpl implements RoomRepositoryCustom{
 				.fetch();
 		long totalElements = getTotalRoomsCount();
 		return new PageImpl<>(rooms, pageable, totalElements);
+	}
+
+	@Override
+	public Optional<Room> findRoomWithCapacity(Long roomId) {
+		Room result = queryFactory
+				.selectFrom(room)
+				.join(room.roomCapacity, roomCapacity).fetchJoin()
+				.where(room.id.eq(roomId))
+				.fetchOne();
+		return Optional.ofNullable(result);
 	}
 
 	private long getTotalRoomsCount() {

--- a/src/main/java/prography/pingpong_game/room/service/RoomService.java
+++ b/src/main/java/prography/pingpong_game/room/service/RoomService.java
@@ -8,6 +8,8 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
+import prography.pingpong_game.common.event.GameEventListener;
+import prography.pingpong_game.common.event.GameStartEvent;
 import prography.pingpong_game.common.exception.ApiStatus;
 import prography.pingpong_game.room.dto.request.*;
 import prography.pingpong_game.room.dto.response.RoomDetailResponse;
@@ -139,6 +141,7 @@ public class RoomService {
         roomValidator.validateRoomWaiting(room);
         //게임 시작
         room.startGame();
+        eventPublisher.publishEvent(new GameStartEvent(roomId));
     }
 
     @Transactional(propagation = Propagation.REQUIRES_NEW)

--- a/src/main/java/prography/pingpong_game/room/service/RoomService.java
+++ b/src/main/java/prography/pingpong_game/room/service/RoomService.java
@@ -1,16 +1,16 @@
 package prography.pingpong_game.room.service;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 import prography.pingpong_game.common.exception.ApiStatus;
-import prography.pingpong_game.room.dto.request.AttendRequest;
-import prography.pingpong_game.room.dto.request.OutRoomRequest;
-import prography.pingpong_game.room.dto.request.TeamSwitchRequest;
+import prography.pingpong_game.room.dto.request.*;
 import prography.pingpong_game.room.dto.response.RoomDetailResponse;
-import prography.pingpong_game.room.dto.request.RoomCreateRequest;
 import prography.pingpong_game.room.dto.response.RoomPageResponse;
 import prography.pingpong_game.room.entity.*;
 import prography.pingpong_game.room.exception.RoomNotFoundException;
@@ -18,15 +18,21 @@ import prography.pingpong_game.room.repository.RoomRepository;
 import prography.pingpong_game.user.entity.User;
 import prography.pingpong_game.user.service.UserService;
 
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class RoomService {
     private final RoomRepository roomRepository;
     private final UserService userService;
     private final RoomValidator roomValidator;
     private final UserRoomValidator userRoomValidator;
     private final UserRoomService userRoomService;
+    private final ApplicationEventPublisher eventPublisher;
+    private final ScheduledExecutorService scheduler = Executors.newScheduledThreadPool(1); // ✅ 스레드 풀 관리
     @Transactional
     public void createRoom(RoomCreateRequest roomCreateRequest) {
         Long userId = roomCreateRequest.userId();
@@ -51,6 +57,13 @@ public class RoomService {
 
     private Room findRoom(Long roomId) {
         Room room = roomRepository.findById(roomId)
+                .orElseThrow(() -> new RoomNotFoundException(ApiStatus.BAD_REQUEST));
+        return room;
+    }
+
+    @Transactional(readOnly = true)
+    public Room findRoomWithCapacity(Long roomId) {
+        Room room = roomRepository.findRoomWithCapacity(roomId)
                 .orElseThrow(() -> new RoomNotFoundException(ApiStatus.BAD_REQUEST));
         return room;
     }
@@ -86,18 +99,18 @@ public class RoomService {
         roomValidator.validateCanExitRoom(room);
 
         if (room.isHost(userId)) {
-            handleHostExit(room);
+            handleExitAllUsers(room);
         } else {
-            handleUserExit(userRoom, room);
+            handleExitUser(userRoom, room);
         }
     }
 
-    private void handleHostExit(Room room) {
+    private void handleExitAllUsers(Room room) {
         userRoomService.deleteAllUserRooms(room.getId());
-        room.finish();
+        room.finishGame();
     }
 
-    private void handleUserExit(UserRoom userRoom, Room room) {
+    private void handleExitUser(UserRoom userRoom, Room room) {
         userRoomService.deleteUser(userRoom);
         room.removeUser(userRoom);
     }
@@ -116,5 +129,22 @@ public class RoomService {
         Team newTeam = currentTeam.getOpposite();
         room.changeUserTeam(currentTeam, newTeam);
         userRoom.switchTeam();
+    }
+
+    @Transactional
+    public void startGame(Long roomId, StartGameRequest startGameRequest) {
+        Room room = findRoom(roomId);
+        roomValidator.validateHost(room, startGameRequest.userId());
+        roomValidator.validateRoomIsFull(room);
+        roomValidator.validateRoomWaiting(room);
+        //게임 시작
+        room.startGame();
+    }
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void finishGame(Long roomId) {
+        Room room = roomRepository.findRoomWithCapacity(roomId).get();
+        room.finishGame();
+        userRoomService.deleteAllUserRooms(room.getId());
     }
 }

--- a/src/main/java/prography/pingpong_game/room/service/RoomValidator.java
+++ b/src/main/java/prography/pingpong_game/room/service/RoomValidator.java
@@ -20,7 +20,18 @@ public class RoomValidator {
 
 	void validateRoomNotFull(Room room) {
 		if (room.isFull()) {
-			throw new RoomCapacityExceededException(ApiStatus.BAD_REQUEST);
+			throw new RoomIsFullException(ApiStatus.BAD_REQUEST);
+		}
+	}
+	void validateRoomIsFull(Room room) {
+		if (!room.isFull()) {
+			throw new RoomIsNotFullException(ApiStatus.BAD_REQUEST);
+		}
+	}
+
+	void validateHost(Room room, Long userId) {
+		if (!room.isHost(userId)) {
+			throw new OnlyHostCanStartGameException(ApiStatus.BAD_REQUEST);
 		}
 	}
 

--- a/src/main/java/prography/pingpong_game/room/service/UserRoomService.java
+++ b/src/main/java/prography/pingpong_game/room/service/UserRoomService.java
@@ -30,11 +30,10 @@ public class UserRoomService {
 		return userRoom;
 	}
 
-	@Transactional
 	public void deleteAllUserRooms(Long roomId) {
 		userRoomRepository.deleteAllByRoomId(roomId);
 	}
-	@Transactional
+
 	public void deleteUser(UserRoom userRoom) {
 		userRoomRepository.delete(userRoom);
 	}


### PR DESCRIPTION
## 📌 관련 이슈
close: #16 

## 💻 작업 내용
게임 시작 api
**1. 게임 시작 시 이벤트 퍼블리셔가 게임 시작 이벤트 등록** 
`@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)`을 사용하여 트랜잭션이 정상적으로 커밋된 후 이벤트가 실행되도록 설정
**2. TaskScheduler.schedule()을 이용하여 게임이 시작된 후 일정 시간이 지나면 자동으로 종료되도록 예약**

## 🗒️ 참고자료




# RCA 룰
- R: 꼭 반영해 주세요. 적극적으로 고려해 주세요. (Request changes)
- C: 웬만하면 반영해 주세요. (Comment)
- A: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다. (Approve)
