### PR TITLE
[refactor] 초기화 동기적으로 변경

### DIFF
--- a/src/main/java/prography/pingpong_game/initialization/service/InitializationService.java
+++ b/src/main/java/prography/pingpong_game/initialization/service/InitializationService.java
@@ -6,6 +6,8 @@ import org.springframework.transaction.annotation.Transactional;
 import prography.pingpong_game.initialization.infra.FakerApiClient;
 import prography.pingpong_game.initialization.infra.FakerApiResponse;
 import prography.pingpong_game.initialization.infra.FakerUserData;
+import prography.pingpong_game.room.repository.RoomRepository;
+import prography.pingpong_game.room.repository.UserRoomRepository;
 import prography.pingpong_game.user.entity.User;
 import prography.pingpong_game.user.entity.UserStatus;
 import prography.pingpong_game.user.repository.UserRepository;
@@ -19,23 +21,28 @@ import java.util.Locale;
 public class InitializationService {
     private final FakerApiClient fakerApiClient;
     private final UserRepository userRepository;
-
-    //TODO yml에서 받아서 쓸지 고민
+    private final RoomRepository roomRepository;
+    private final UserRoomRepository userRoomRepository;
     private static final int activeUserMaxFakerId = 30;
     private static final int waitUserMaxFakerId = 60;
 
     @Transactional
     public void initialize(int seed, int quantity) {
-        //TODO: 기존에 있던 모든 회원 정보 및 방 정보를 삭제(방 정보 삭제 해야 함)
+        clearData();  // 기존 데이터를 삭제
+        FakerApiResponse fakerApiResponse = fakerApiClient.fetchUsers(seed, quantity, Locale.KOREA).block();
+        if (fakerApiResponse != null) {
+            List<User> users = fakerApiResponse.data().stream()
+                    .map(this::convertToUser)
+                    .sorted(Comparator.comparing(User::getFakerId))
+                    .toList();
+            userRepository.saveAll(users);
+        }
+    }
+
+    private void clearData() {
+        userRoomRepository.deleteAll();
+        roomRepository.deleteAll();
         userRepository.deleteAll();
-        fakerApiClient.fetchUsers(seed, quantity, Locale.KOREA)
-                .subscribe(fakerApiResponse -> {
-                    List<User> users = fakerApiResponse.data().stream()
-                            .map(this::convertToUser)
-                            .sorted(Comparator.comparing(User::getFakerId))
-                            .toList();
-                    userRepository.saveAll(users);
-                });
     }
 
     private User convertToUser(FakerUserData fakerUserData) {
@@ -46,6 +53,7 @@ public class InitializationService {
                 determineUserStatus(fakerUserData.id())
         );
     }
+
     private UserStatus determineUserStatus(Long fakerId) {
         return UserStatus.fromFakerId(fakerId, activeUserMaxFakerId, waitUserMaxFakerId);
     }

--- a/src/main/java/prography/pingpong_game/room/entity/Room.java
+++ b/src/main/java/prography/pingpong_game/room/entity/Room.java
@@ -27,7 +27,7 @@ public class Room extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private RoomStatus status;
 
-    @OneToOne(cascade = CascadeType.PERSIST, fetch = FetchType.LAZY)
+    @OneToOne(cascade = CascadeType.ALL, fetch = FetchType.LAZY)
     @JoinColumn(name = "room_capacity_id")
     private RoomCapacity roomCapacity;
 


### PR DESCRIPTION
## 📌 관련 이슈
close: #5 

## 💻 작업 내용
- 초기화 로직 변경 (유저만 삭제하던거에서 유저룸, 룸 모두 삭제)
- 트랜잭션 문제가 생길 수 있기 때문에 webclient api 호출 동기적으로 실행 

## 🗒️ 참고자료



# RCA 룰
- R: 꼭 반영해 주세요. 적극적으로 고려해 주세요. (Request changes)
- C: 웬만하면 반영해 주세요. (Comment)
- A: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다. (Approve)
